### PR TITLE
feat: last_updated column of class is updated when new event is added

### DIFF
--- a/backend/src/apiserver/lib/model/entities.py
+++ b/backend/src/apiserver/lib/model/entities.py
@@ -272,3 +272,7 @@ class NewTrainingEvent(BaseModel):
     date: date
     event_id: str
     description: str = ""
+
+
+class EventDate(BaseModel):
+    date: date

--- a/test.nu
+++ b/test.nu
@@ -17,6 +17,11 @@ def check_backend [] {
     poetry run mypy
 }
 
+def lint_fix [] {
+    cd $backend_dir
+    poetry run ruff src tests --fix
+}
+
 # Run pyest and run the formatter, linter and type checker
 def "main backend" [] {
     print "Testing and checking backend..."
@@ -28,6 +33,12 @@ def "main backend" [] {
 def "main pytest" [] {
     print "Testing backend..."
     pytest_backend
+}
+
+# Run pytest on the backend
+def "main lint:fix" [] {
+    print "Linting and fixing issues..."
+    lint_fix
 }
 
 


### PR DESCRIPTION
Previously, we didn't update the `last_updated` column of a classification. Now, when a new event is added to a classification, this is updated automatically.

See https://github.com/DSAV-Dodeka/commissie/issues/7

* lint:fix optie in `test.nu`. 