### PR TITLE
feat: ranking metadata

### DIFF
--- a/backend/actions/local_actions.py
+++ b/backend/actions/local_actions.py
@@ -166,12 +166,12 @@ async def test_add_classification(local_dsrc):
 @pytest.mark.asyncio
 async def test_update_points(local_dsrc):
     async with get_conn(local_dsrc) as conn:
-        training_class = await data.classifications.most_recent_class_of_type(
+        training_class = (await data.classifications.most_recent_class_of_type(
             conn, "training"
-        )
-        points_class = await data.classifications.most_recent_class_of_type(
+        ))[0]
+        points_class = (await data.classifications.most_recent_class_of_type(
             conn, "points"
-        )
+        ))[0]
         await update_class_points(conn, training_class.classification_id)
         await update_class_points(conn, points_class.classification_id)
 

--- a/backend/src/apiserver/app/ops/startup.py
+++ b/backend/src/apiserver/app/ops/startup.py
@@ -1,4 +1,5 @@
 from apiserver.app.error import AppError, ErrorKeys
+from apiserver.data.special import update_class_points
 from loguru import logger
 from asyncio import sleep
 from datetime import date
@@ -199,8 +200,11 @@ async def initial_population(dsrc: Source, config: Config) -> None:
         user_id = await data.user.insert_return_user_id(conn, fake_user)
         assert user_id == "1_fakerecord"
 
-        await insert_classification(conn, "training")
-        await insert_classification(conn, "points")
+        new_training_id = await insert_classification(conn, "training")
+        new_points_id = await insert_classification(conn, "points")
+
+        await update_class_points(conn, new_training_id, False)
+        await update_class_points(conn, new_points_id, False)
 
 
 async def get_keystate(dsrc: Source) -> KeyState:

--- a/backend/src/apiserver/app/routers/ranking.py
+++ b/backend/src/apiserver/app/routers/ranking.py
@@ -91,7 +91,7 @@ async def get_classification(
     return RawJSONResponse(UserPointsNamesList.dump_json(user_points))
 
 
-async def get_classification_with_meta(
+async def get_classification_with_info(
     dsrc: Source, ctx: RankingContext, rank_type: str, admin: bool = False
 ) -> RawJSONResponse:
     if not is_rank_type(rank_type):
@@ -105,6 +105,15 @@ async def get_classification_with_meta(
 
     ranking_info = await context_most_recent_class_points(ctx, dsrc, rank_type, admin)
     return RawJSONResponse(RankingInfo.model_dump_json(ranking_info).encode())
+
+
+@ranking_members_router.get("/get_with_info/{rank_type}/", response_model=RankingInfo)
+async def member_classification_with_info(
+    rank_type: str, dsrc: SourceDep, app_context: AppContext
+) -> RawJSONResponse:
+    return await get_classification_with_info(
+        dsrc, app_context.rank_ctx, rank_type, False
+    )
 
 
 @ranking_admin_router.get("/get_meta/{recent_number}/", response_model=list[ClassView])

--- a/backend/src/apiserver/data/api/classifications.py
+++ b/backend/src/apiserver/data/api/classifications.py
@@ -1,11 +1,15 @@
 from datetime import date, timedelta
 from typing import Literal
+from schema.model.model import CLASS_END_DATE
 
 from sqlalchemy import RowMapping
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from apiserver.lib.model.entities import (
     ClassEvent,
+    ClassMeta,
+    ClassMetaList,
+    ClassUpdate,
     Classification,
     ClassView,
     EventDate,
@@ -46,7 +50,9 @@ from store.db import (
     lit_model,
     select_some_join_where,
     select_some_where,
+    update_by_unique,
     update_column_by_unique,
+    upsert_by_unique,
 )
 from store.error import DataError, NoDataError, DbError, DbErrors
 
@@ -75,8 +81,8 @@ async def insert_classification(
 
 
 async def most_recent_class_of_type(
-    conn: AsyncConnection, class_type: Literal["training", "points"]
-) -> ClassView:
+    conn: AsyncConnection, class_type: Literal["training", "points"], amount: int = 1
+) -> list[ClassMeta]:
     if class_type == "training":
         query_class_type = "training"
     elif class_type == "points":
@@ -90,11 +96,11 @@ async def most_recent_class_of_type(
     largest_class_list = await get_largest_where(
         conn,
         CLASSIFICATION_TABLE,
-        {CLASS_ID, CLASS_LAST_UPDATED, CLASS_START_DATE, CLASS_HIDDEN_DATE},
+        {CLASS_ID, CLASS_LAST_UPDATED, CLASS_START_DATE, CLASS_HIDDEN_DATE, CLASS_END_DATE},
         CLASS_TYPE,
         query_class_type,
         CLASS_START_DATE,
-        1,
+        amount,
     )
     if len(largest_class_list) == 0:
         raise NoDataError(
@@ -102,7 +108,7 @@ async def most_recent_class_of_type(
             "no_most_recent_training_class",
         )
 
-    return ClassView.model_validate(largest_class_list[0])
+    return ClassMetaList.validate_python(largest_class_list)
 
 
 async def all_points_in_class(
@@ -260,3 +266,9 @@ async def class_update_last_updated(
     return await update_column_by_unique(
         conn, CLASSIFICATION_TABLE, CLASS_LAST_UPDATED, date, CLASS_ID, class_id
     )
+
+async def update_classification(
+    conn: AsyncConnection, class_view: ClassUpdate
+) -> None:
+
+    await update_by_unique(conn, CLASSIFICATION_TABLE, lit_model(class_view), "classification_id", class_view.classification_id)

--- a/backend/src/apiserver/data/context/app_context.py
+++ b/backend/src/apiserver/data/context/app_context.py
@@ -20,7 +20,6 @@ from apiserver.lib.model.entities import (
     ClassEvent,
     ClassMeta,
     ClassUpdate,
-    ClassView,
     NewEvent,
     RankingInfo,
     UserData,
@@ -104,23 +103,21 @@ class RankingContext(Context):
         cls, dsrc: Source, event_id: str
     ) -> list[UserPointsNames]:
         raise ContextNotImpl()
-    
+
     @classmethod
     async def most_recent_classes(
         cls, dsrc: Source, amount: int = 10
     ) -> list[ClassMeta]:
         raise ContextNotImpl()
-    
+
     @classmethod
-    async def context_new_classes(
-        cls, dsrc: Source
-    ) -> None:
+    async def context_new_classes(cls, dsrc: Source) -> None:
         raise ContextNotImpl()
-    
+
     @classmethod
     async def context_modify_class(
-        cls, dsrc: Source, class_update: ClassUpdate 
-    ) -> None:  
+        cls, dsrc: Source, class_update: ClassUpdate
+    ) -> None:
         raise ContextNotImpl()
 
 

--- a/backend/src/apiserver/data/context/app_context.py
+++ b/backend/src/apiserver/data/context/app_context.py
@@ -18,6 +18,9 @@ from auth.data.context import Contexts
 from apiserver.data import Source
 from apiserver.lib.model.entities import (
     ClassEvent,
+    ClassMeta,
+    ClassUpdate,
+    ClassView,
     NewEvent,
     RankingInfo,
     UserData,
@@ -100,6 +103,24 @@ class RankingContext(Context):
     async def context_get_event_users(
         cls, dsrc: Source, event_id: str
     ) -> list[UserPointsNames]:
+        raise ContextNotImpl()
+    
+    @classmethod
+    async def most_recent_classes(
+        cls, dsrc: Source, amount: int = 10
+    ) -> list[ClassMeta]:
+        raise ContextNotImpl()
+    
+    @classmethod
+    async def context_new_classes(
+        cls, dsrc: Source
+    ) -> None:
+        raise ContextNotImpl()
+    
+    @classmethod
+    async def context_modify_class(
+        cls, dsrc: Source, class_update: ClassUpdate 
+    ) -> None:  
         raise ContextNotImpl()
 
 

--- a/backend/src/apiserver/data/context/app_context.py
+++ b/backend/src/apiserver/data/context/app_context.py
@@ -19,6 +19,7 @@ from apiserver.data import Source
 from apiserver.lib.model.entities import (
     ClassEvent,
     NewEvent,
+    RankingInfo,
     UserData,
     User,
     UserEvent,
@@ -76,7 +77,7 @@ class RankingContext(Context):
     @classmethod
     async def context_most_recent_class_points(
         cls, dsrc: Source, rank_type: Literal["points", "training"], is_admin: bool
-    ) -> list[UserPointsNames]:
+    ) -> RankingInfo:
         raise ContextNotImpl()
 
     @classmethod

--- a/backend/src/apiserver/data/context/ranking.py
+++ b/backend/src/apiserver/data/context/ranking.py
@@ -9,6 +9,8 @@ from store.error import DataError
 
 from apiserver.lib.model.entities import (
     ClassEvent,
+    ClassMeta,
+    ClassUpdate,
     ClassView,
     NewEvent,
     NewTrainingEvent,
@@ -25,7 +27,9 @@ from apiserver.data.api.classifications import (
     class_update_last_updated,
     events_in_class,
     get_event_user_points,
+    insert_classification,
     most_recent_class_of_type,
+    update_classification,
 )
 from apiserver.data.context import RankingContext
 from apiserver.data.source import get_conn
@@ -49,7 +53,7 @@ async def add_new_event(dsrc: Source, new_event: NewEvent) -> None:
     date. Use the 'publish' function to force them to be equal."""
     async with get_conn(dsrc) as conn:
         try:
-            classification = await most_recent_class_of_type(conn, new_event.class_type)
+            classification = (await most_recent_class_of_type(conn, new_event.class_type))[0]
         except DataError as e:
             if e.key != "incorrect_class_type":
                 raise e
@@ -135,17 +139,17 @@ async def context_most_recent_class_id_of_type(
     dsrc: Source, rank_type: Literal["points", "training"]
 ) -> int:
     async with get_conn(dsrc) as conn:
-        class_id = (await most_recent_class_of_type(conn, rank_type)).classification_id
+        class_id = (await most_recent_class_of_type(conn, rank_type))[0].classification_id
 
     return class_id
 
 
 @ctx_reg.register(RankingContext)
 async def context_most_recent_class_points(
-    dsrc: Source, rank_type: Literal["points", "training"], is_admin: bool
+    dsrc: Source, rank_type: Literal["points", "training"], is_admin: bool,
 ) -> RankingInfo:
     async with get_conn(dsrc) as conn:
-        class_view = await most_recent_class_of_type(conn, rank_type)
+        class_view = (await most_recent_class_of_type(conn, rank_type))[0]
         user_points = await all_points_in_class(
             conn, class_view.classification_id, is_admin
         )
@@ -161,8 +165,8 @@ async def context_most_recent_class_points(
 @ctx_reg.register(RankingContext)
 async def sync_publish_ranking(dsrc: Source, publish: bool) -> None:
     async with get_conn(dsrc) as conn:
-        training_class = await most_recent_class_of_type(conn, "training")
-        points_class = await most_recent_class_of_type(conn, "points")
+        training_class = (await most_recent_class_of_type(conn, "training"))[0]
+        points_class = (await most_recent_class_of_type(conn, "points"))[0]
         await update_class_points(conn, training_class.classification_id, publish)
         await update_class_points(conn, points_class.classification_id, publish)
 
@@ -192,3 +196,38 @@ async def context_get_event_users(dsrc: Source, event_id: str) -> list[UserPoint
         events_points = await get_event_user_points(conn, event_id)
 
     return events_points
+
+
+@ctx_reg.register(RankingContext)
+async def most_recent_classes(
+    dsrc: Source, amount: int = 10
+) -> list[ClassMeta]:
+    if amount < 2 or amount % 2 != 0:
+        raise AppError(
+                ErrorKeys.DATA,
+                "Request at least 2 classes and make sure it is an even number!",
+                "most_recent_too_few",
+            )
+    
+    async with get_conn(dsrc) as conn:
+        training_classes = (await most_recent_class_of_type(conn, "training", amount // 2))
+        points_classes = (await most_recent_class_of_type(conn, "points", amount // 2))
+
+    return training_classes + points_classes
+
+
+@ctx_reg.register(RankingContext)
+async def context_new_classes(
+    dsrc: Source
+) -> None:    
+    async with get_conn(dsrc) as conn:
+        await insert_classification(conn, "training")
+        await insert_classification(conn, "points")
+
+
+@ctx_reg.register(RankingContext)
+async def context_modify_class(
+    dsrc: Source, class_update: ClassUpdate 
+) -> None:    
+    async with get_conn(dsrc) as conn:
+        await update_classification(conn, class_update)

--- a/backend/src/apiserver/lib/model/entities.py
+++ b/backend/src/apiserver/lib/model/entities.py
@@ -272,3 +272,7 @@ class NewTrainingEvent(BaseModel):
     date: date
     event_id: str
     description: str = ""
+
+
+class EventDate(BaseModel):
+    date: date

--- a/backend/src/apiserver/lib/model/entities.py
+++ b/backend/src/apiserver/lib/model/entities.py
@@ -282,3 +282,16 @@ class NewTrainingEvent(BaseModel):
 
 class EventDate(BaseModel):
     date: date
+
+
+class ClassMeta(ClassView):
+    end_date: date
+
+
+class ClassUpdate(BaseModel):
+    classification_id: int
+    start_date: date
+    hidden_date: date
+    end_date: date
+
+ClassMetaList = TypeAdapter(List[ClassMeta])

--- a/backend/src/apiserver/lib/model/entities.py
+++ b/backend/src/apiserver/lib/model/entities.py
@@ -285,6 +285,7 @@ class EventDate(BaseModel):
 
 
 class ClassMeta(ClassView):
+    type: Literal["points", "training"]
     end_date: date
 
 
@@ -293,5 +294,6 @@ class ClassUpdate(BaseModel):
     start_date: date
     hidden_date: date
     end_date: date
+
 
 ClassMetaList = TypeAdapter(List[ClassMeta])

--- a/backend/src/apiserver/lib/model/entities.py
+++ b/backend/src/apiserver/lib/model/entities.py
@@ -223,6 +223,12 @@ class UserPointsNames(BaseModel):
 UserPointsNamesList = TypeAdapter(List[UserPointsNames])
 
 
+class RankingInfo(BaseModel):
+    last_updated: date
+    frozen: bool
+    points: list[UserPointsNames]
+
+
 # class PointsData(BaseModel):
 #     points: int
 

--- a/backend/src/store/db.py
+++ b/backend/src/store/db.py
@@ -238,9 +238,7 @@ async def update_by_unique(
 
     _, _, row_keys_set = _row_keys_vars_set(set_dict)
 
-    query = text(
-        f"UPDATE {table} SET {row_keys_set} WHERE {unique_column} = :val;"
-    )
+    query = text(f"UPDATE {table} SET {row_keys_set} WHERE {unique_column} = :val;")
     val_dict: LiteralDict = {"val": value}
     params = set_dict | val_dict
 

--- a/backend/src/store/db.py
+++ b/backend/src/store/db.py
@@ -227,6 +227,27 @@ async def upsert_by_unique(
     return row_cnt(res)
 
 
+async def update_by_unique(
+    conn: AsyncConnection,
+    table: LiteralString,
+    set_dict: LiteralDict,
+    unique_column: LiteralString,
+    value: Any,
+) -> int:
+    """Note that while the values are safe from injection, the column names are not."""
+
+    _, _, row_keys_set = _row_keys_vars_set(set_dict)
+
+    query = text(
+        f"UPDATE {table} SET {row_keys_set} WHERE {unique_column} = :val;"
+    )
+    val_dict: LiteralDict = {"val": value}
+    params = set_dict | val_dict
+
+    res = await execute_catch(conn, query, parameters=params)
+    return row_cnt(res)
+
+
 async def update_column_by_unique(
     conn: AsyncConnection,
     table: LiteralString,

--- a/dev.nu
+++ b/dev.nu
@@ -10,7 +10,7 @@ def pull [envnmt: string, env_file: string, profile: string] {
 }
 
 def up [envnmt: string, env_file: string, profile: string] {
-    pull $envnmt $env_file $profile
+    # pull $envnmt $env_file $profile
     docker compose -f $"($deploy_dir)/use/($envnmt)/docker-compose.yml" --env-file $"($deploy_dir)/use/($envnmt)/($env_file).env" --profile $profile up -d
 }
 

--- a/test.nu
+++ b/test.nu
@@ -17,6 +17,11 @@ def check_backend [] {
     poetry run mypy
 }
 
+def lint_fix [] {
+    cd $backend_dir
+    poetry run ruff src tests --fix
+}
+
 # Run pyest and run the formatter, linter and type checker
 def "main backend" [] {
     print "Testing and checking backend..."
@@ -28,6 +33,12 @@ def "main backend" [] {
 def "main pytest" [] {
     print "Testing backend..."
     pytest_backend
+}
+
+# Run pytest on the backend
+def "main lint:fix" [] {
+    print "Linting and fixing issues..."
+    lint_fix
 }
 
 


### PR DESCRIPTION
Een aantal nieuwe endpoints voor de nieuwe class update:

* `<server>/admin/class/get_meta/{recent_number}/` (this returns the most recent classifications of each type, recent_number/2 for each type)
* `<server>/admin/class/new/` (creates a new points and training classification)
*  `<server>/admin/class/modify/` (modifies a classification)
*  `<server>/admin/class/remove/{class_id}` (removes classification with id class_id)

Gebruik nu ClassMeta ipv ClassView op nieuwe plekken, laat most_recent_class_of_type nu een lijst returnen van een variabel aantal klassementen (en dan ClassMeta, die alle info heeft). ClassView wordt nog wel op oude plekken gebruikt maar ClassMeta inherit van ClassView dus die werkt nog steeds.

* Nieuwe `update_by_unique` database functie.