### PR TITLE
Csv fix

### DIFF
--- a/backend/src/apiserver/sync.py
+++ b/backend/src/apiserver/sync.py
@@ -193,6 +193,19 @@ def is_cancelled(opzegdatum: str, today: date | None = None) -> bool:
 def parse_csv(content: str) -> list[VoltaRow]:
     if content.startswith("\ufeff"):
         content = content[1:]
+
+    # Some exports wrap each data row in outer quotes — unwrap them so
+    # csv.DictReader can parse the fields correctly.
+    lines = content.splitlines()
+    if lines:
+        cleaned_lines = [lines[0].strip()]
+        for line in lines[1:]:
+            line = line.strip()
+            if line.startswith('"') and line.endswith('"'):
+                line = line[1:-1].replace('""', '"')
+            cleaned_lines.append(line)
+        content = "\n".join(cleaned_lines)
+
     entries = []
     reader = csv.DictReader(io.StringIO(content))
     if reader.fieldnames is not None:

--- a/backend/src/apiserver/sync.py
+++ b/backend/src/apiserver/sync.py
@@ -200,10 +200,10 @@ def parse_csv(content: str) -> list[VoltaRow]:
     if lines:
         cleaned_lines = [lines[0].strip()]
         for line in lines[1:]:
-            line = line.strip()
-            if line.startswith('"') and line.endswith('"'):
-                line = line[1:-1].replace('""', '"')
-            cleaned_lines.append(line)
+            stripped = line.strip()
+            if stripped.startswith('"') and stripped.endswith('"'):
+                stripped = stripped[1:-1].replace('""', '"')
+            cleaned_lines.append(stripped)
         content = "\n".join(cleaned_lines)
 
     entries = []


### PR DESCRIPTION
### Fix CSV import failing for exports with quoted rows

The CSV export wraps each data row in outer quotes (e.g. "1234,Jan,,Jansen,M,...") which caused csv.DictReader to treat the entire line as a single field. This resulted in all columns except the first being None, crashing with 'NoneType' object has no attribute 'strip'.

Added a pre-processing step in parse_csv that strips outer quotes from data rows and unescapes doubled quotes before passing the content to DictReader.